### PR TITLE
Fixed #3166

### DIFF
--- a/packages/twenty-front/src/modules/object-record/utils/generateEmptyFieldValue.ts
+++ b/packages/twenty-front/src/modules/object-record/utils/generateEmptyFieldValue.ts
@@ -51,6 +51,10 @@ export const generateEmptyFieldValue = (
 
     case FieldMetadataType.MultiSelect:
     case FieldMetadataType.Select: {
+      return [];
+    }
+
+    default: {
       throw new Error('Not implemented yet');
     }
   }


### PR DESCRIPTION
- Added handling for FieldMetadataType.MultiSelect and FieldMetadataType.Select cases in the generateEmptyFieldValue function.
- Returned an empty array as the default value for these field types.